### PR TITLE
Playing around with options passing to take T or &T

### DIFF
--- a/sdk/client_new_method_builder/examples/set_secret_method_builder.rs
+++ b/sdk/client_new_method_builder/examples/set_secret_method_builder.rs
@@ -47,22 +47,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     ctx.insert("example".to_string());
 
     let (_, _) = tokio::join!(
-        async {
-            client
-                .set_secret("foo", "foo-value")
-                .with_content_type("text/plain")
-                .with_context(ctx.clone())
-                .send()
-                .await
-        },
-        async {
-            client
-                .set_secret("bar", "bar-value")
-                .with_content_type("text/plain")
-                .with_context(ctx.clone())
-                .send()
-                .await
-        },
+        client
+            .set_secret("foo", "foo-value")
+            .with_content_type("text/plain")
+            .with_context(ctx.clone())
+            .send(),
+        client
+            .set_secret("bar", "bar-value")
+            .with_content_type("text/plain")
+            .with_context(ctx.clone())
+            .send()
+        ,
     );
 
     Ok(())

--- a/sdk/client_new_method_params/examples/set_secret_params.rs
+++ b/sdk/client_new_method_params/examples/set_secret_params.rs
@@ -17,7 +17,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ..Default::default()
         },
     };
-    let client = SecretClient::new(endpoint, credential, Some(options))?;
+
+    // Just showing that we can do both
+    let client = SecretClient::new(endpoint.clone(), credential.clone(), Some(&options))?;
+    let client2 = SecretClient::new(endpoint, credential, Some(options))?;
 
     // Simple client method call.
     let response = client
@@ -58,9 +61,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ..Default::default()
     };
 
-    let (_, _) = tokio::join!(
+    let (_, _, _) = tokio::join!(
         client.set_secret("foo", "foo-value", Some(options.clone())),
-        client.set_secret("bar", "bar-value", Some(options.clone())),
+        client.set_secret2("bar", "bar-value", Some(&options)),
+        client.set_secret2("bar", "bar-value", Some(&options)),
     );
 
     Ok(())

--- a/sdk/client_new_method_params/src/lib.rs
+++ b/sdk/client_new_method_params/src/lib.rs
@@ -7,7 +7,8 @@ use azure_core::{
     ClientOptions, Context, Pipeline, Request, Response, Result, Span, TokenCredential, Url,
 };
 pub use models::*;
-use std::{collections::HashMap, sync::Arc};
+use std::{borrow::Cow, collections::HashMap, sync::Arc};
+
 
 #[derive(Debug, Clone)]
 pub struct SecretClient {
@@ -16,12 +17,15 @@ pub struct SecretClient {
 }
 
 impl SecretClient {
-    pub fn new(
+    pub fn new<'a>(
         endpoint: impl AsRef<str>,
         credential: Arc<dyn TokenCredential>,
-        options: Option<SecretClientOptions>,
+        options: Option<impl Into<Cow<'a, SecretClientOptions>>>,
     ) -> Result<Self> {
-        let options = options.unwrap_or_default();
+        let options = options
+            .map(|o| o.into())
+            .unwrap_or_else(|| Cow::Owned(SecretClientOptions::default()));
+
         let mut endpoint = Url::parse(endpoint.as_ref())?;
         endpoint
             .query_pairs_mut()
@@ -78,6 +82,37 @@ impl SecretClient {
 
         self.pipeline.send(&mut ctx, &mut request).await
     }
+
+    #[allow(unused_variables)]
+    pub async fn set_secret2<'a, N, V>(
+        &self,
+        name: N,
+        value: V,
+        options: Option<impl Into<Cow<'a, SetSecretOptions>>>,
+    ) -> azure_core::Result<Response>
+    where
+        N: Into<String>,
+        V: Into<String>,
+    {
+        let options = options
+            .map(|o| o.into())
+            .unwrap_or_else(|| Cow::Owned(SetSecretOptions::default()));
+
+        let mut ctx = options.context.clone().unwrap_or_default();
+        ctx.insert(Span::from("SecretClient::set_secret"));
+
+        let mut url = self.endpoint.clone();
+        url.set_path(&format!("secrets/{}", name.into()));
+
+        let mut request = Request::new(url, "GET");
+        request.set_json(&SetSecretRequest {
+            value: value.into(),
+            properties: options.properties.clone(),
+            ..Default::default()
+        })?;
+
+        self.pipeline.send(&mut ctx, &mut request).await
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -95,10 +130,36 @@ impl Default for SecretClientOptions {
     }
 }
 
+// Used to make options passing work for both T and &T
+impl<'a> From<&'a SecretClientOptions> for Cow<'a, SecretClientOptions> {
+    fn from(original: &'a SecretClientOptions) -> Self {
+        Cow::Borrowed(original)
+    }
+}
+
+impl<'a> From<SecretClientOptions> for Cow<'a, SecretClientOptions> {
+    fn from(original: SecretClientOptions) -> Self {
+        Cow::Owned(original)
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct SetSecretOptions {
     pub properties: Option<SecretProperties>,
     pub content_type: Option<String>,
     pub tags: Option<HashMap<String, String>>,
     pub context: Option<Context>,
+}
+
+// Used to make options passing work for both T and &T
+impl<'a> From<&'a SetSecretOptions> for Cow<'a, SetSecretOptions> {
+    fn from(original: &'a SetSecretOptions) -> Self {
+        Cow::Borrowed(original)
+    }
+}
+
+impl<'a> From<SetSecretOptions> for Cow<'a, SetSecretOptions> {
+    fn from(original: SetSecretOptions) -> Self {
+        Cow::Owned(original)
+    }
 }


### PR DESCRIPTION
Just playing around with what passing options by ref or val could look like using the easiest way possible.

Two things to note:

1. Client construction is still going to need to take ownership of values inside of the options via copying or cloning if we don't want the client to be dependent on the lifetime of the options (I don't think we want that).  The constructor will still be dependent on the lifetime of the options, but that's fine and unavoidable.
2. Methods that can take options by ref or value become problematic as they are written, as they will be dependent on the lifetime of the options.  This isn't a problem for sharing options between calls, but it does prevent modifying a reused option while there are outstanding calls.  We could solve this by telling users to clone in the case where they want to do this, or we can change the client methods from being async fn's that implicitly capture the lifetime, to non async fn's that capture the lifetime, but return a request future that is independent of the options lifetime.

Not a really meant for merging.