### PR TITLE
Changes for mock prototype

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -2,10 +2,12 @@
   "version": "0.2",
   "language": "en",
   "words": [
+    "automock",
     "clippy",
     "discoverability",
     "etag",
     "keyvault",
+    "mockall",
     "rustlang",
     "rustup",
     "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,8 +66,10 @@ dependencies = [
 name = "azure_client_new_methods_params"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "azure_core",
  "azure_identity",
+ "mockall",
  "serde",
  "tokio",
 ]
@@ -140,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +161,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "futures"
@@ -266,6 +286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +310,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
+]
+
+[[package]]
+name = "mockall"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "lazy_static",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -322,6 +375,32 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "predicates"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b87bfd4605926cdfefc1c3b5f8fe560e3feca9d5552cf68c466d3d8236c7e8"
+dependencies = [
+ "anstyle",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -403,6 +482,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "tinyvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ azure_core = { version = "0.1.0", path = "sdk/core" }
 azure_identity = { version = "0.1.0", path = "sdk/identity" }
 bytes = "1.5.0"
 futures = "0.3.30"
+mockall = "0.12.1"
 serde_json = "1.0.114"
 serde = { version = "1.0.197", features = ["derive"] }
 tokio = { version = "1.36.0", features = ["macros", "rt-multi-thread"] }

--- a/sdk/client_new_method_params/Cargo.toml
+++ b/sdk/client_new_method_params/Cargo.toml
@@ -3,11 +3,17 @@ name = "azure_client_new_methods_params"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version = { workspace = true }
 
 [dependencies]
+async-trait = { workspace = true }
 azure_core = { workspace = true, features = ["context"] }
+mockall = { workspace = true, optional = true }
 serde = { workspace = true }
 
 [dev-dependencies]
 azure_identity = { workspace = true }
 tokio = { workspace = true }
+
+[features]
+mock = [ "dep:mockall" ]

--- a/sdk/client_new_method_params/examples/set_secret_params.rs
+++ b/sdk/client_new_method_params/examples/set_secret_params.rs
@@ -1,5 +1,6 @@
 use azure_client_new_methods_params::{
-    Secret, SecretClient, SecretClientOptions, SecretProperties, SetSecretOptions,
+    Secret, SecretClient, SecretClientMethods, SecretClientOptions, SecretProperties,
+    SetSecretOptions,
 };
 use azure_core::{ClientOptions, Context, ExponentialRetryOptions, RetryOptions};
 use azure_identity::DefaultAzureCredential;

--- a/sdk/client_new_method_params/src/models.rs
+++ b/sdk/client_new_method_params/src/models.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "mock", derive(Serialize))]
 pub struct Secret {
     pub name: String,
     pub version: String,

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "azure_core"
 version = "0.1.0"
 edition = "2021"
 publish = false
+rust-version = { workspace = true }
 
 [dependencies]
 async-trait = { workspace = true }


### PR DESCRIPTION
While we can take an optional dependency on `mockall`, it does force some constraints on our code that would affect all callers:

1. We need to add `'static` lifetimes to parameters.
2. We need to attribute traits with `#[async_trait::async_trait]`, which forces the `Send` constraint on parameters.

I tried several ways of using `mockall::mock!()` but, under a self-imposed timebox, I was not able to get it to work with any async method or method returning an `impl Future` - presumably because of the same issues as above but obscured by using a procedural macro.