### PR TITLE
Rename "builder" to "builders"

### DIFF
--- a/sdk/client_builder_method_builder/Cargo.toml
+++ b/sdk/client_builder_method_builder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-azure_core = { workspace = true, features = ["builder", "context"] }
+azure_core = { workspace = true, features = ["builders", "context"] }
 futures = { workspace = true }
 serde = { workspace = true }
 

--- a/sdk/client_method_options_builder/Cargo.toml
+++ b/sdk/client_method_options_builder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-azure_core = { workspace = true, features = ["builder", "context"] }
+azure_core = { workspace = true, features = ["builders", "context"] }
 serde = { workspace = true }
 
 [dev-dependencies]

--- a/sdk/client_method_options_builder/src/lib.rs
+++ b/sdk/client_method_options_builder/src/lib.rs
@@ -90,7 +90,7 @@ impl SecretClientOptions {
         self.api_version.as_str()
     }
 
-    pub fn builder() -> builder::SecretClientOptionsBuilder {
+    pub fn builder() -> builders::SecretClientOptionsBuilder {
         todo!()
     }
 }
@@ -125,12 +125,12 @@ impl SetSecretOptions {
         self.tags.as_ref()
     }
 
-    pub fn builder() -> builder::SetSecretOptionsBuilder {
+    pub fn builder() -> builders::SetSecretOptionsBuilder {
         todo!()
     }
 }
 
-pub mod builder {
+pub mod builders {
     use super::*;
     use azure_core::{ClientMethodOptionsBuilder, ClientOptionsBuilder};
 

--- a/sdk/client_new_method_builder/Cargo.toml
+++ b/sdk/client_new_method_builder/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-azure_core = { workspace = true, features = ["builder", "context"] }
+azure_core = { workspace = true, features = ["builders", "context"] }
 futures = { workspace = true }
 serde = { workspace = true }
 

--- a/sdk/core/Cargo.toml
+++ b/sdk/core/Cargo.toml
@@ -16,7 +16,7 @@ url = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 
 [features]
-builder = []
+builders = []
 context = []
 
 [lints]

--- a/sdk/core/src/options/mod.rs
+++ b/sdk/core/src/options/mod.rs
@@ -1,8 +1,8 @@
 mod retry;
 mod transport;
 
-#[cfg(feature = "builder")]
-pub use builder::*;
+#[cfg(feature = "builders")]
+pub use builders::*;
 pub use retry::*;
 pub use transport::*;
 
@@ -45,7 +45,7 @@ impl ClientMethodOptions {
     }
 }
 
-mod builder {
+mod builders {
     use super::*;
 
     pub trait ClientBuilder {


### PR DESCRIPTION
Match plurality of "options", "policies" modules, etc.
